### PR TITLE
Transpile ISA ansatz and hamiltonian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,4 @@ HamilToniQ/our_results/.DS_Store
 personal/
 general_test.ipynb
 .gitignore
+benchmark/

--- a/hamiltoniq/benchmark.py
+++ b/hamiltoniq/benchmark.py
@@ -32,8 +32,6 @@ from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from .utility import (
     Q_to_paulis,
     all_quantum_states,
-    get_transpiled_index_layout,
-    reorder_bits,
 )
 from .instances import *
 
@@ -325,7 +323,7 @@ class Toniq:
         dec_ground_state = ground_state_info["dec_state"]
         accuracy_list = []
         for res in data:
-            qc = ansatz.bind_parameters(res.x)
+            qc = ansatz.assign_parameters(res.x)
             sv = Statevector(qc)
             accuracy_list.append(abs(sv[dec_ground_state]) ** 2)
         return accuracy_list
@@ -417,9 +415,7 @@ class Toniq:
         )
 
         # analyse the results and get a score
-        accuracy_list = self.get_accuracy_processor(
-            results_list, n_qubits, n_layers, globals()[f"qubits_{n_qubits}"]
-        )
+        accuracy_list = self.get_accuracy_processor(results_list, n_qubits, n_layers)
 
         # plot the accuracy list
         if plot_results is True:

--- a/hamiltoniq/benchmark.py
+++ b/hamiltoniq/benchmark.py
@@ -322,17 +322,12 @@ class Toniq:
         """
         ansatz = QAOAAnsatz(self.op, reps=n_layers)
         ground_state_info = globals()[f"ground_{n_qubits}"]
-        bin_ground_state = ground_state_info["bin_state"]
+        dec_ground_state = ground_state_info["dec_state"]
         accuracy_list = []
         for res in data:
-            # Replace bind_parameters with assign_parameters
-            qc = ansatz.assign_parameters(res.x)
-            qc_isa = self.pm.run(qc)
-            sv = Statevector(qc_isa)
-            # Convert dec_state based on transpiled circuit layout
-            new_layout_order = get_transpiled_index_layout(qc_isa)
-            _, new_dec_ground_state = reorder_bits(bin_ground_state, new_layout_order)
-            accuracy_list.append(abs(sv[new_dec_ground_state]) ** 2)
+            qc = ansatz.bind_parameters(res.x)
+            sv = Statevector(qc)
+            accuracy_list.append(abs(sv[dec_ground_state]) ** 2)
         return accuracy_list
 
     def simulator_run(

--- a/hamiltoniq/benchmark.py
+++ b/hamiltoniq/benchmark.py
@@ -27,7 +27,6 @@ from qiskit.quantum_info import Statevector, SparsePauliOp
 from qiskit_ibm_runtime import Estimator
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from functools import partial
-from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 
 from .utility import (
     Q_to_paulis,

--- a/hamiltoniq/utility.py
+++ b/hamiltoniq/utility.py
@@ -58,31 +58,3 @@ def simple_coupling_map() -> list[Tuple[int, int]]:
 
     coupling_map = [[0, 1], [1, 2], [1, 3], [3, 5], [4, 5], [5, 6]]
     return coupling_map
-
-
-def get_transpiled_index_layout(
-    tqc: QuantumCircuit, filter_ancillas: None = True
-) -> List[int]:
-    """Return the transpiled index layout of a circuit.
-    Args:
-        tqc: The circuit to get the transpiled index layout of.
-    Returns:
-        The transpiled index layout of the circuit.
-    """
-    return tqc.layout.final_index_layout(filter_ancillas=filter_ancillas)
-
-
-def reorder_bits(binary, new_order):
-    """
-    Reorder the bits of a binary string.
-    Args:
-        binary: The binary string to reorder.
-        new_order: The new order of the bits.
-    Returns:
-        The binary string with the bits reordered.
-    """
-    binary_str = str(binary)
-    # Create a new binary string based on the new order
-    new_binary = "".join(binary_str[i] for i in new_order)
-    decimal_value = int(new_binary, 2)
-    return new_binary, decimal_value

--- a/hamiltoniq/utility.py
+++ b/hamiltoniq/utility.py
@@ -6,7 +6,6 @@ from typing import List, Any, Callable, Dict, Tuple
 
 import numpy as np
 from qiskit.quantum_info import Statevector, SparsePauliOp
-from qiskit import QuantumCircuit
 
 matrix = Any
 circuit = Any

--- a/hamiltoniq/utility.py
+++ b/hamiltoniq/utility.py
@@ -6,6 +6,7 @@ from typing import List, Any, Callable, Dict, Tuple
 
 import numpy as np
 from qiskit.quantum_info import Statevector, SparsePauliOp
+from qiskit import QuantumCircuit
 
 matrix = Any
 circuit = Any
@@ -57,3 +58,31 @@ def simple_coupling_map() -> list[Tuple[int, int]]:
 
     coupling_map = [[0, 1], [1, 2], [1, 3], [3, 5], [4, 5], [5, 6]]
     return coupling_map
+
+
+def get_transpiled_index_layout(
+    tqc: QuantumCircuit, filter_ancillas: None = True
+) -> List[int]:
+    """Return the transpiled index layout of a circuit.
+    Args:
+        tqc: The circuit to get the transpiled index layout of.
+    Returns:
+        The transpiled index layout of the circuit.
+    """
+    return tqc.layout.final_index_layout(filter_ancillas=filter_ancillas)
+
+
+def reorder_bits(binary, new_order):
+    """
+    Reorder the bits of a binary string.
+    Args:
+        binary: The binary string to reorder.
+        new_order: The new order of the bits.
+    Returns:
+        The binary string with the bits reordered.
+    """
+    binary_str = str(binary)
+    # Create a new binary string based on the new order
+    new_binary = "".join(binary_str[i] for i in new_order)
+    decimal_value = int(new_binary, 2)
+    return new_binary, decimal_value


### PR DESCRIPTION
Address issue #5 
- Transpile ansatz and op in `get_results_processor` to ISA follow IBMQ update (https://docs.quantum.ibm.com/announcements/news/2024-05-06-ISA-circuit-requirement)
- Use `ansatz_isa` for `get_accuracy_processor`

